### PR TITLE
feature: Added logic to save teams bots as participants

### DIFF
--- a/src/Application/Common/Models/ResourceIdentity.cs
+++ b/src/Application/Common/Models/ResourceIdentity.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace Application.Common.Models
+{
+    public class ResourceIdentity
+    {
+        public string Id { get; set; }
+
+        public string DisplayName { get; set; }
+    }
+}

--- a/src/BotService/Infrastructure/Core/CallHandler.cs
+++ b/src/BotService/Infrastructure/Core/CallHandler.cs
@@ -585,11 +585,13 @@ namespace BotService.Infrastructure.Core
                 // for now we want the bot to only subscribe to "real" participants
                 try
                 {
-                    _logger.LogInformation("[CallHandler] Adding participant with graph id {id} - Participant: {participant}.", participant.Id, participant.ToJson());
+                    _logger.LogInformation("[CallHandler] Adding participant with graph id {id}", participant.Id);
+                    _logger.LogDebug("[CallHandler] Adding participant with graph id {id} - Participant: {participant}.", participant.Id, participant.ToJson());
                     if (participant.IsAnAllowedParticipant())
                     {
                         var callId = Call.ScenarioId.ToString();
-                        _logger.LogInformation("[CallHandler] Participant to be added: {participant}", participant.ToJson());
+                        _logger.LogInformation("[CallHandler] Participant with graph id {id} to be added", participant.Id);
+                        _logger.LogDebug("[CallHandler] Participant to be added: {participant}", participant.ToJson());
 
                         await _mediatorService.AddParticipantStreamAsync(callId, participant);
 

--- a/src/BotService/Infrastructure/Core/CallHandler.cs
+++ b/src/BotService/Infrastructure/Core/CallHandler.cs
@@ -585,8 +585,8 @@ namespace BotService.Infrastructure.Core
                 // for now we want the bot to only subscribe to "real" participants
                 try
                 {
-                    _logger.LogInformation("[CallHandler] Adding participant with graph id {id}.", participant.Id);
-                    if (participant.IsUser() || participant.IsGuestUser() || participant.IsLiveEventBot())
+                    _logger.LogInformation("[CallHandler] Adding participant with graph id {id} - Participant: {participant}.", participant.Id, participant.ToJson());
+                    if (participant.IsAnAllowedParticipant())
                     {
                         var callId = Call.ScenarioId.ToString();
                         _logger.LogInformation("[CallHandler] Participant to be added: {participant}", participant.ToJson());

--- a/src/Domain/Constants/Constants.cs
+++ b/src/Domain/Constants/Constants.cs
@@ -74,6 +74,12 @@ namespace Domain.Constants
             public const string ScreenShare = "Screen Share";
         }
 
+        public static class MicrosoftTeamsBotApplicationType
+        {
+            public const string TogetherMode = "TogetherMode";
+            public const string LargeGallery = "LargeGallery";
+        }
+
         public static class Messages
         {
             public static class StartExtraction


### PR DESCRIPTION
## Purpose
Be able to extract the feeds of the Together mode, Large Gallery, and live event bots as if they were participants.