### PR TITLE
Fix/shut down media platform 

### DIFF
--- a/src/BotService/Infrastructure/Core/Bot.cs
+++ b/src/BotService/Infrastructure/Core/Bot.cs
@@ -28,7 +28,7 @@ using Microsoft.Skype.Bots.Media;
 
 namespace BotService.Infrastructure.Core
 {
-    public class Bot : IBot
+    public class Bot : IBot, IDisposable
     {
         private readonly ICommunicationsClient _client;
         private readonly IMediatorService _mediatorService;
@@ -166,6 +166,21 @@ namespace BotService.Infrastructure.Core
         {
             var callHandler = CallHandlers.First().Value;
             callHandler.StopExtraction(streamBody);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Release the resources used by the Media Platform
+                MediaPlatform.Shutdown();
+            }
         }
 
         #region Private

--- a/src/BotService/Infrastructure/Extensions/WebHostServiceExtensions.cs
+++ b/src/BotService/Infrastructure/Extensions/WebHostServiceExtensions.cs
@@ -15,7 +15,11 @@ namespace BotService.Infrastructure.Extensions
     {
         public static void RunAsCustomService(this IWebHost host)
         {
-            var webHostService = new HostService(host);
+            var webHostService = new HostService(host)
+            {
+                // Set the service name to identify logs in the Windows Event Viewer
+                ServiceName = "bot-bervice",
+            };
             ServiceBase.Run(webHostService);
         }
 

--- a/src/BotService/Infrastructure/Extensions/WebHostServiceExtensions.cs
+++ b/src/BotService/Infrastructure/Extensions/WebHostServiceExtensions.cs
@@ -15,11 +15,7 @@ namespace BotService.Infrastructure.Extensions
     {
         public static void RunAsCustomService(this IWebHost host)
         {
-            var webHostService = new HostService(host)
-            {
-                // Set the service name to identify logs in the Windows Event Viewer
-                ServiceName = "bot-bervice",
-            };
+            var webHostService = new HostService(host);
             ServiceBase.Run(webHostService);
         }
 

--- a/src/BotService/Infrastructure/WindowsService/HostService.cs
+++ b/src/BotService/Infrastructure/WindowsService/HostService.cs
@@ -19,6 +19,9 @@ namespace BotService.Infrastructure.WindowsService
         {
             _webHost = host;
             _logger = host.Services.GetRequiredService<ILogger<HostService>>();
+
+            // Set the service name to identify logs in the Windows Event Viewer
+            ServiceName = "bot-bervice";
         }
 
         protected override void OnStarting(string[] args)


### PR DESCRIPTION
## Purpose
Allow shut down the Media Platform to release the resources when the Bot is stopped.

## Approach
Call the `ShutDown()` method provided by the [Microsoft.Skype.Bots.Media](https://microsoftgraph.github.io/microsoft-graph-comms-samples/docs/bot_media/Microsoft.Skype.Bots.Media.MediaPlatform.html#Microsoft_Skype_Bots_Media_MediaPlatform_Shutdown) to stop the Media Platform properly when disposing the Bot.
