### PR TITLE
Update BotService.csproj

### DIFF
--- a/src/BotService/BotService.csproj
+++ b/src/BotService/BotService.csproj
@@ -51,7 +51,7 @@
     <PackageReference Include="Microsoft.Graph.Communications.Client" Version="1.2.0.3144" />
     <PackageReference Include="Microsoft.Graph.Communications.Common" Version="1.2.0.3144" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.8.0" />
-    <PackageReference Include="Microsoft.Skype.Bots.Media" Version="1.20.0.348-alpha" />
+    <PackageReference Include="Microsoft.Skype.Bots.Media" Version="1.21.0.241-alpha" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />


### PR DESCRIPTION
Microsoft.Skype.Bots.Media library updated to version 1.21.0.241.

## Purpose
Keep the Skype Bots Media library updated.

## Approach
Updated and tested with the new version.
