### PR TITLE
refactor: rename commands

### DIFF
--- a/src/Application/Call/Commands/RequestInviteBot.cs
+++ b/src/Application/Call/Commands/RequestInviteBot.cs
@@ -18,7 +18,7 @@ using Domain.Exceptions;
 using FluentValidation;
 using MediatR;
 using Microsoft.Azure.Management.Compute.Fluent;
-using static Application.Service.Commands.InviteBot;
+using static Application.Service.Commands.DoInviteBot;
 
 namespace Application.Call.Commands
 {
@@ -133,7 +133,7 @@ namespace Application.Call.Commands
 
                 await _serviceRepository.UpdateItemAsync(service.Id, service);
 
-                var inviteBotCommand = new InviteBotCommand
+                var inviteBotCommand = new DoInviteBotCommand
                 {
                     CallId = call.Id,
                     MeetingId = request.MeetingId,

--- a/src/Application/Call/Commands/RequestMuteBot.cs
+++ b/src/Application/Call/Commands/RequestMuteBot.cs
@@ -9,24 +9,24 @@ using MediatR;
 
 namespace Application.Stream.Commands
 {
-    public class RequestMuteBotFromCall
+    public class RequestMuteBot
     {
-        public class RequestMuteBotFromCallCommand : IRequest<RequestMuteBotFromCallCommandResponse>
+        public class RequestMuteBotCommand : IRequest<RequestMuteBotCommandResponse>
         {
             public string CallId { get; set; }
         }
 
-        public class RequestMuteBotFromCallCommandResponse
+        public class RequestMuteBotCommandResponse
         {
         }
 
-        public class RequestMuteBotFromCallCommandHandler : IRequestHandler<RequestMuteBotFromCallCommand, RequestMuteBotFromCallCommandResponse>
+        public class RequestMuteBotCommandHandler : IRequestHandler<RequestMuteBotCommand, RequestMuteBotCommandResponse>
         {
             private readonly IBotServiceClient _botServiceClient;
             private readonly ICallRepository _callRepository;
             private readonly IServiceRepository _serviceRepository;
 
-            public RequestMuteBotFromCallCommandHandler(
+            public RequestMuteBotCommandHandler(
                 IBotServiceClient botServiceClient,
                 ICallRepository callRepository,
                 IServiceRepository serviceRepository)
@@ -36,7 +36,7 @@ namespace Application.Stream.Commands
                 _serviceRepository = serviceRepository ?? throw new ArgumentNullException(nameof(serviceRepository));
             }
 
-            public async Task<RequestMuteBotFromCallCommandResponse> Handle(RequestMuteBotFromCallCommand request, CancellationToken cancellationToken)
+            public async Task<RequestMuteBotCommandResponse> Handle(RequestMuteBotCommand request, CancellationToken cancellationToken)
             {
                 var call = await _callRepository.GetItemAsync(request.CallId);
                 var service = await _serviceRepository.GetItemAsync(call.ServiceId);

--- a/src/Application/Call/Commands/RequestUnmuteBot.cs
+++ b/src/Application/Call/Commands/RequestUnmuteBot.cs
@@ -9,24 +9,24 @@ using MediatR;
 
 namespace Application.Call.Commands
 {
-    public class RequestUnmuteBotFromCall
+    public class RequestUnmuteBot
     {
-        public class RequestUnmuteBotFromCallCommand : IRequest<RequestUnmuteBotFromCallCommandResponse>
+        public class RequestUnmuteBotCommand : IRequest<RequestUnmuteBotCommandResponse>
         {
             public string CallId { get; set; }
         }
 
-        public class RequestUnmuteBotFromCallCommandResponse
+        public class RequestUnmuteBotCommandResponse
         {
         }
 
-        public class RequestUnmuteBotFromCallCommandHandler : IRequestHandler<RequestUnmuteBotFromCallCommand, RequestUnmuteBotFromCallCommandResponse>
+        public class RequestUnmuteBotCommandHandler : IRequestHandler<RequestUnmuteBotCommand, RequestUnmuteBotCommandResponse>
         {
             private readonly IBotServiceClient _botServiceClient;
             private readonly ICallRepository _callRepository;
             private readonly IServiceRepository _serviceRepository;
 
-            public RequestUnmuteBotFromCallCommandHandler(
+            public RequestUnmuteBotCommandHandler(
                 IBotServiceClient botServiceClient,
                 ICallRepository callRepository,
                 IServiceRepository serviceRepository)
@@ -36,7 +36,7 @@ namespace Application.Call.Commands
                 _serviceRepository = serviceRepository ?? throw new ArgumentNullException(nameof(serviceRepository));
             }
 
-            public async Task<RequestUnmuteBotFromCallCommandResponse> Handle(RequestUnmuteBotFromCallCommand request, CancellationToken cancellationToken)
+            public async Task<RequestUnmuteBotCommandResponse> Handle(RequestUnmuteBotCommand request, CancellationToken cancellationToken)
             {
                 var call = await _callRepository.GetItemAsync(request.CallId);
                 var service = await _serviceRepository.GetItemAsync(call.ServiceId);

--- a/src/Application/Interfaces/Common/IBot.cs
+++ b/src/Application/Interfaces/Common/IBot.cs
@@ -3,7 +3,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Application.Common.Models;
-using static Application.Service.Commands.InviteBot;
+using static Application.Service.Commands.DoInviteBot;
 
 namespace Application.Interfaces.Common
 {
@@ -13,7 +13,7 @@ namespace Application.Interfaces.Common
 
         string VirtualMachineName { get; set; }
 
-        Task InviteBotAsync(InviteBotCommand command);
+        Task InviteBotAsync(DoInviteBotCommand command);
 
         Task ProcessNotificationAsync(HttpRequestMessage request);
 

--- a/src/Application/Interfaces/Common/IBotServiceClient.cs
+++ b/src/Application/Interfaces/Common/IBotServiceClient.cs
@@ -9,7 +9,7 @@ namespace Application.Interfaces.Common
 {
     public interface IBotServiceClient
     {
-        Task<HttpResponseMessage> InviteBotAsync(InviteBot.InviteBotCommand command);
+        Task<HttpResponseMessage> InviteBotAsync(DoInviteBot.DoInviteBotCommand command);
 
         Task<HttpResponseMessage> RemoveBotAsync(string callGraphId);
 

--- a/src/Application/Service/Commands/DoInviteBot.cs
+++ b/src/Application/Service/Commands/DoInviteBot.cs
@@ -8,9 +8,9 @@ using MediatR;
 
 namespace Application.Service.Commands
 {
-    public class InviteBot
+    public class DoInviteBot
     {
-        public class InviteBotCommand : IRequest<InviteBotCommandResponse>
+        public class DoInviteBotCommand : IRequest<DoInviteBotCommandResponse>
         {
             public string MeetingUrl { get; set; }
 
@@ -19,14 +19,14 @@ namespace Application.Service.Commands
             public string CallId { get; set; }
         }
 
-        public class InviteBotCommandResponse
+        public class DoInviteBotCommandResponse
         {
             public string Id { get; set; }
         }
 
-        public class InviteBotCommandValidator : AbstractValidator<InviteBotCommand>
+        public class DoInviteBotCommandValidator : AbstractValidator<DoInviteBotCommand>
         {
-            public InviteBotCommandValidator()
+            public DoInviteBotCommandValidator()
             {
                 RuleFor(x => x.MeetingUrl)
                     .NotEmpty();
@@ -35,18 +35,18 @@ namespace Application.Service.Commands
             }
         }
 
-        public class InviteBotCommandHandler : IRequestHandler<InviteBotCommand, InviteBotCommandResponse>
+        public class DoInviteBotCommandHandler : IRequestHandler<DoInviteBotCommand, DoInviteBotCommandResponse>
         {
             private readonly IBot _bot;
 
-            public InviteBotCommandHandler(IBot bot)
+            public DoInviteBotCommandHandler(IBot bot)
             {
                 _bot = bot;
             }
 
-            public async Task<InviteBotCommandResponse> Handle(InviteBotCommand request, CancellationToken cancellationToken)
+            public async Task<DoInviteBotCommandResponse> Handle(DoInviteBotCommand request, CancellationToken cancellationToken)
             {
-                InviteBotCommandResponse response = new InviteBotCommandResponse();
+                DoInviteBotCommandResponse response = new DoInviteBotCommandResponse();
 
                 await _bot.InviteBotAsync(request);
 

--- a/src/Application/Service/Commands/DoMuteBot.cs
+++ b/src/Application/Service/Commands/DoMuteBot.cs
@@ -7,26 +7,26 @@ using MediatR;
 
 namespace Application.Service.Commands
 {
-    public class MuteBot
+    public class DoMuteBot
     {
-        public class MuteBotCommand : IRequest<MuteBotCommandResponse>
+        public class DoMuteBotCommand : IRequest<DoMuteBotCommandResponse>
         {
         }
 
-        public class MuteBotCommandResponse
+        public class DoMuteBotCommandResponse
         {
         }
 
-        public class MuteBotCommandHandler : IRequestHandler<MuteBotCommand, MuteBotCommandResponse>
+        public class DoMuteBotCommandHandler : IRequestHandler<DoMuteBotCommand, DoMuteBotCommandResponse>
         {
             private readonly IBot _bot;
 
-            public MuteBotCommandHandler(IBot bot)
+            public DoMuteBotCommandHandler(IBot bot)
             {
                 _bot = bot;
             }
 
-            public async Task<MuteBotCommandResponse> Handle(MuteBotCommand request, CancellationToken cancellationToken)
+            public async Task<DoMuteBotCommandResponse> Handle(DoMuteBotCommand request, CancellationToken cancellationToken)
             {
                 await _bot.MuteBotAsync();
                 return null;

--- a/src/Application/Service/Commands/DoUnmuteBot.cs
+++ b/src/Application/Service/Commands/DoUnmuteBot.cs
@@ -7,29 +7,29 @@ using MediatR;
 
 namespace Application.Service.Commands
 {
-    public class UnmuteBot
+    public class DoUnmuteBot
     {
-        public class UnmuteBotCommand : IRequest<UnmuteBotCommandResponse>
+        public class DoUnmuteBotCommand : IRequest<DoUnmuteBotCommandResponse>
         {
         }
 
-        public class UnmuteBotCommandResponse
+        public class DoUnmuteBotCommandResponse
         {
             public string Id { get; set; }
         }
 
-        public class UnmuteBotCommandHandler : IRequestHandler<UnmuteBotCommand, UnmuteBotCommandResponse>
+        public class DoUnmuteBotCommandHandler : IRequestHandler<DoUnmuteBotCommand, DoUnmuteBotCommandResponse>
         {
             private readonly IBot _bot;
 
-            public UnmuteBotCommandHandler(IBot bot)
+            public DoUnmuteBotCommandHandler(IBot bot)
             {
                 _bot = bot;
             }
 
-            public async Task<UnmuteBotCommandResponse> Handle(UnmuteBotCommand request, CancellationToken cancellationToken)
+            public async Task<DoUnmuteBotCommandResponse> Handle(DoUnmuteBotCommand request, CancellationToken cancellationToken)
             {
-                var response = new UnmuteBotCommandResponse();
+                var response = new DoUnmuteBotCommandResponse();
 
                 await _bot.UnmuteBotAsync();
 

--- a/src/Application/Service/Commands/RequestStartServiceInfrastructure.cs
+++ b/src/Application/Service/Commands/RequestStartServiceInfrastructure.cs
@@ -10,31 +10,31 @@ using Domain.Constants;
 using Domain.Enums;
 using Domain.Exceptions;
 using MediatR;
-using static Application.Service.Commands.StartServiceInfrastructure;
+using static Application.Service.Commands.DoStartServiceInfrastructure;
 
 namespace Application.Service.Commands
 {
-    public class StartingServiceInfrastructure
+    public class RequestStartServiceInfrastructure
     {
-        public class StartingServiceInfrastructureCommand : IRequest<StartingServiceInfrastructureCommandResponse>
+        public class RequestStartServiceInfrastructureCommand : IRequest<RequestStartServiceInfrastructureCommandResponse>
         {
             public string ServiceId { get; set; }
         }
 
-        public class StartingServiceInfrastructureCommandResponse
+        public class RequestStartServiceInfrastructureCommandResponse
         {
             public string Id { get; set; }
 
             public ServiceModel Resource { get; set; }
         }
 
-        public class StartingServiceInfrastructureCommandHandler : IRequestHandler<StartingServiceInfrastructureCommand, StartingServiceInfrastructureCommandResponse>
+        public class RequestStartServiceInfrastructureCommandHandler : IRequestHandler<RequestStartServiceInfrastructureCommand, RequestStartServiceInfrastructureCommandResponse>
         {
             private readonly IServiceRepository _serviceRepository;
             private readonly IAzStorageHandler _storageHandler;
             private readonly IMapper _mapper;
 
-            public StartingServiceInfrastructureCommandHandler(
+            public RequestStartServiceInfrastructureCommandHandler(
                 IServiceRepository serviceRepository,
                 IAzStorageHandler storageHandler,
                 IMapper mapper)
@@ -44,9 +44,9 @@ namespace Application.Service.Commands
                 _mapper = mapper;
             }
 
-            public async Task<StartingServiceInfrastructureCommandResponse> Handle(StartingServiceInfrastructureCommand request, CancellationToken cancellationToken)
+            public async Task<RequestStartServiceInfrastructureCommandResponse> Handle(RequestStartServiceInfrastructureCommand request, CancellationToken cancellationToken)
             {
-                var response = new StartingServiceInfrastructureCommandResponse();
+                var response = new RequestStartServiceInfrastructureCommandResponse();
                 /* TODO: Change this.
                   NOTE: The Management Portal does not have the feature to select the service before initializing the call.
                   The following code is temporary, if the service Id is not specified, we use a harcoded ID to retrieve the service.
@@ -66,7 +66,7 @@ namespace Application.Service.Commands
                 service.Infrastructure.ProvisioningDetails.Message = $"Provisioning service {service.Name}.";
                 await _serviceRepository.UpdateItemAsync(service.Id, service);
 
-                var startVirtualMachineCommand = new StartServiceInfrastructureCommand
+                var startVirtualMachineCommand = new DoStartServiceInfrastructureCommand
                 {
                     Id = service.Id,
                 };

--- a/src/Application/Service/Commands/RequestStopServiceInfrastructure.cs
+++ b/src/Application/Service/Commands/RequestStopServiceInfrastructure.cs
@@ -10,31 +10,31 @@ using Domain.Constants;
 using Domain.Enums;
 using Domain.Exceptions;
 using MediatR;
-using static Application.Service.Commands.StopServiceInfrastructure;
+using static Application.Service.Commands.DoStopServiceInfrastructure;
 
 namespace Application.Service.Commands
 {
-    public class StoppingServiceInfrastructure
+    public class RequestStopServiceInfrastructure
     {
-        public class StoppingServiceInfrastructureCommand : IRequest<StoppingServiceInfrastructureCommandResponse>
+        public class RequestStopServiceInfrastructureCommand : IRequest<RequestStopServiceInfrastructureCommandResponse>
         {
             public string ServiceId { get; set; }
         }
 
-        public class StoppingServiceInfrastructureCommandResponse
+        public class RequestStopServiceInfrastructureCommandResponse
         {
             public string Id { get; set; }
 
             public ServiceModel Resource { get; set; }
         }
 
-        public class StoppingServiceInfrastructureCommandHandler : IRequestHandler<StoppingServiceInfrastructureCommand, StoppingServiceInfrastructureCommandResponse>
+        public class RequestStopServiceInfrastructureCommandHandler : IRequestHandler<RequestStopServiceInfrastructureCommand, RequestStopServiceInfrastructureCommandResponse>
         {
             private readonly IServiceRepository _serviceRepository;
             private readonly IAzStorageHandler _storageHandler;
             private readonly IMapper _mapper;
 
-            public StoppingServiceInfrastructureCommandHandler(
+            public RequestStopServiceInfrastructureCommandHandler(
                 IServiceRepository serviceRepository,
                 IAzStorageHandler storageHandler,
                 IMapper mapper)
@@ -44,9 +44,9 @@ namespace Application.Service.Commands
                 _mapper = mapper ?? throw new System.ArgumentNullException(nameof(mapper));
             }
 
-            public async Task<StoppingServiceInfrastructureCommandResponse> Handle(StoppingServiceInfrastructureCommand request, CancellationToken cancellationToken)
+            public async Task<RequestStopServiceInfrastructureCommandResponse> Handle(RequestStopServiceInfrastructureCommand request, CancellationToken cancellationToken)
             {
-                var response = new StoppingServiceInfrastructureCommandResponse();
+                var response = new RequestStopServiceInfrastructureCommandResponse();
 
                 /* TODO: Change this.
                    NOTE: The Management Portal does not have the feature to select the service before initializing the call.
@@ -67,7 +67,7 @@ namespace Application.Service.Commands
                 service.Infrastructure.ProvisioningDetails.Message = $"Deprovisioning service {service.Name}";
                 await _serviceRepository.UpdateItemAsync(service.Id, service);
 
-                var stopServiceInfrastructureCommand = new StopServiceInfrastructureCommand
+                var stopServiceInfrastructureCommand = new DoStopServiceInfrastructureCommand
                 {
                     Id = service.Id,
                 };

--- a/src/Application/Service/MappingProfile.cs
+++ b/src/Application/Service/MappingProfile.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 using Application.Common.Models;
 using AutoMapper;
-using static Application.Service.Commands.StartingServiceInfrastructure;
-using static Application.Service.Commands.StartServiceInfrastructure;
-using static Application.Service.Commands.StoppingServiceInfrastructure;
-using static Application.Service.Commands.StopServiceInfrastructure;
+using static Application.Service.Commands.RequestStartServiceInfrastructure;
+using static Application.Service.Commands.DoStartServiceInfrastructure;
+using static Application.Service.Commands.RequestStopServiceInfrastructure;
+using static Application.Service.Commands.DoStopServiceInfrastructure;
 
 namespace Application.Service
 {
@@ -19,10 +19,10 @@ namespace Application.Service
             CreateMap<Domain.Entities.Service, ServiceModel>();
             CreateMap<Domain.Entities.Parts.Infrastructure, InfrastructureModel>();
             CreateMap<Domain.Entities.Parts.ProvisioningDetails, ProvisioningDetailsModel>();
-            CreateMap<Domain.Entities.Service, StartServiceInfrastructureCommand>();
-            CreateMap<Domain.Entities.Service, StopServiceInfrastructureCommand>();
-            CreateMap<Domain.Entities.Service, StartingServiceInfrastructureCommandResponse>();
-            CreateMap<Domain.Entities.Service, StoppingServiceInfrastructureCommandResponse>();
+            CreateMap<Domain.Entities.Service, DoStartServiceInfrastructureCommand>();
+            CreateMap<Domain.Entities.Service, DoStopServiceInfrastructureCommand>();
+            CreateMap<Domain.Entities.Service, RequestStartServiceInfrastructureCommandResponse>();
+            CreateMap<Domain.Entities.Service, RequestStopServiceInfrastructureCommandResponse>();
         }
     }
 }

--- a/src/BotService/Controllers/BotController.cs
+++ b/src/BotService/Controllers/BotController.cs
@@ -34,7 +34,7 @@ namespace BotService.Controllers
         // POST api/<BotController>
         [HttpPost]
         [Route("invite")]
-        public async Task<IActionResult> InviteBotAsync([FromBody] InviteBot.InviteBotCommand command)
+        public async Task<IActionResult> InviteBotAsync([FromBody] DoInviteBot.DoInviteBotCommand command)
         {
             var response = await _mediator.Send(command);
 
@@ -59,7 +59,7 @@ namespace BotService.Controllers
         [Route("mute")]
         public async Task<ActionResult> MuteAsync()
         {
-            var command = new MuteBot.MuteBotCommand();
+            var command = new DoMuteBot.DoMuteBotCommand();
             var response = await _mediator.Send(command);
             return Ok(response);
         }
@@ -68,7 +68,7 @@ namespace BotService.Controllers
         [Route("unmute")]
         public async Task<ActionResult> UnmuteAsync()
         {
-            var command = new UnmuteBot.UnmuteBotCommand();
+            var command = new DoUnmuteBot.DoUnmuteBotCommand();
             var response = await _mediator.Send(command);
             return Ok(response);
         }

--- a/src/BotService/Infrastructure/Core/Bot.cs
+++ b/src/BotService/Infrastructure/Core/Bot.cs
@@ -68,7 +68,7 @@ namespace BotService.Infrastructure.Core
 
         public string VirtualMachineName { get; set; }
 
-        public async Task InviteBotAsync(InviteBot.InviteBotCommand command)
+        public async Task InviteBotAsync(DoInviteBot.DoInviteBotCommand command)
         {
             _logger.LogInformation("[Bot] Getting meeting info for call {callId}", command.CallId);
 

--- a/src/Infrastructure.Core/Services/BotServiceClient.cs
+++ b/src/Infrastructure.Core/Services/BotServiceClient.cs
@@ -38,7 +38,7 @@ namespace Infrastructure.Core.Services
             _baseUrl = baseUrl;
         }
 
-        public async Task<HttpResponseMessage> InviteBotAsync(InviteBot.InviteBotCommand command)
+        public async Task<HttpResponseMessage> InviteBotAsync(DoInviteBot.DoInviteBotCommand command)
         {
             ValidateBaseUrl();
 

--- a/src/ManagementApi/Controllers/CallController.cs
+++ b/src/ManagementApi/Controllers/CallController.cs
@@ -165,7 +165,7 @@ namespace ManagementApi.Controllers
         [Route("{callId}/mute")]
         public async Task<ActionResult> MuteAsync([FromRoute] string callId)
         {
-            var command = new RequestMuteBotFromCall.RequestMuteBotFromCallCommand
+            var command = new RequestMuteBot.RequestMuteBotCommand
             {
                 CallId = callId,
             };
@@ -177,7 +177,7 @@ namespace ManagementApi.Controllers
         [Route("{callId}/unmute")]
         public async Task<ActionResult> UnmuteAsync([FromRoute] string callId)
         {
-            var command = new RequestUnmuteBotFromCall.RequestUnmuteBotFromCallCommand
+            var command = new RequestUnmuteBot.RequestUnmuteBotCommand
             {
                 CallId = callId,
             };

--- a/src/ManagementApi/Controllers/ServiceController.cs
+++ b/src/ManagementApi/Controllers/ServiceController.cs
@@ -23,7 +23,7 @@ namespace ManagementApi.Controllers
         [Route("{serviceId}/start")]
         public async Task<IActionResult> Start([FromRoute] string serviceId)
         {
-            var command = new StartingServiceInfrastructure.StartingServiceInfrastructureCommand
+            var command = new RequestStartServiceInfrastructure.RequestStartServiceInfrastructureCommand
             {
                 ServiceId = serviceId,
             };
@@ -45,7 +45,7 @@ namespace ManagementApi.Controllers
         [Route("{serviceId}/stop")]
         public async Task<IActionResult> Stop([FromRoute] string serviceId)
         {
-            var command = new StoppingServiceInfrastructure.StoppingServiceInfrastructureCommand
+            var command = new RequestStopServiceInfrastructure.RequestStopServiceInfrastructureCommand
             {
                 ServiceId = serviceId,
             };

--- a/src/OrchestratorFunction/OrchestratorFunctions.cs
+++ b/src/OrchestratorFunction/OrchestratorFunctions.cs
@@ -9,8 +9,8 @@ using Microsoft.Azure.WebJobs.Extensions.EventGrid;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using static Application.Service.Commands.HandleEventGridServiceInfrastructureEvent;
-using static Application.Service.Commands.StartServiceInfrastructure;
-using static Application.Service.Commands.StopServiceInfrastructure;
+using static Application.Service.Commands.DoStartServiceInfrastructure;
+using static Application.Service.Commands.DoStopServiceInfrastructure;
 
 namespace BotOrchestrator
 {
@@ -28,7 +28,7 @@ namespace BotOrchestrator
         }
 
         [FunctionName("start-virtual-machine")]
-        public async Task StartVirtualMachineAsync([QueueTrigger(Constants.AzureQueueNames.StartVirtualMachineQueue, Connection = Constants.StorageAccountSettingName)] StartServiceInfrastructureCommand command)
+        public async Task StartVirtualMachineAsync([QueueTrigger(Constants.AzureQueueNames.StartVirtualMachineQueue, Connection = Constants.StorageAccountSettingName)] DoStartServiceInfrastructureCommand command)
         {
             _logger.LogInformation("C# Queue trigger function processed: {command}", JsonConvert.SerializeObject(command));
 
@@ -38,7 +38,7 @@ namespace BotOrchestrator
         }
 
         [FunctionName("stop-virtual-machine")]
-        public async Task StopVirtualMachineAsync([QueueTrigger(Constants.AzureQueueNames.StopVirtualMachineQueue, Connection = Constants.StorageAccountSettingName)] StopServiceInfrastructureCommand command)
+        public async Task StopVirtualMachineAsync([QueueTrigger(Constants.AzureQueueNames.StopVirtualMachineQueue, Connection = Constants.StorageAccountSettingName)] DoStopServiceInfrastructureCommand command)
         {
             _logger.LogInformation("C# Queue trigger function processed: {command}", JsonConvert.SerializeObject(command));
 


### PR DESCRIPTION
## Purpose
This PR renames some commands to add consistency to the codebase. Nowadays, there are some actions like invite bot or start/stop extraction that are triggered by the Management API and executed by the Bot Service API. The commands called by the Management API that make requests to the BotService API use the prefix request, while the commands called by the Bot Service API use the prefix do.